### PR TITLE
Use native pgx types, context everywhere

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -1,16 +1,20 @@
 package migration
 
+import "context"
+
 // Driver is the interface type that needs to implemented by all drivers.
 type Driver interface {
 	// Close is the last function to be called.
 	// Close any open connection here.
-	Close() error
+	Close(ctx context.Context) error
 
 	// Migrate is the heart of the driver.
 	// It will receive a PlannedMigration which the driver should apply
 	// to its backend or whatever.
-	Migrate(migration *PlannedMigration) error
+	//
+	// Context can be used to cancel any incomplete migrations.
+	Migrate(ctx context.Context, migration *PlannedMigration) error
 
 	// Version returns all applied migration versions
-	Versions() ([]string, error)
+	Versions(ctx context.Context) ([]string, error)
 }

--- a/driver/postgres/go.mod
+++ b/driver/postgres/go.mod
@@ -3,7 +3,6 @@ module github.com/GRVYDEV/migration/driver/postgres
 go 1.17
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/GRVYDEV/migration v0.21.5
 	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgx/v4 v4.14.1
@@ -80,6 +79,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.9.1 // indirect
+	github.com/jackc/puddle v1.2.0 // indirect
 	github.com/jgautheron/goconst v1.5.1 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af // indirect

--- a/driver/postgres/go.sum
+++ b/driver/postgres/go.sum
@@ -58,7 +58,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
@@ -68,7 +67,6 @@ github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy86
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
-github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
@@ -486,6 +484,7 @@ github.com/jackc/pgx/v4 v4.14.1/go.mod h1:RgDuE4Z34o7XE92RpLsvFiOEfrAUT0Xt2KxvX7
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.2.0 h1:DNDKdn/pDrWvDWyT2FYvpZVE81OAhWrjCv19I9n108Q=
 github.com/jackc/puddle v1.2.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=

--- a/migration_test.go
+++ b/migration_test.go
@@ -1,9 +1,11 @@
 package migration
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 )
 
 func TestDirectionString(t *testing.T) {
@@ -120,6 +122,9 @@ func TestMigrationSortingWithNonNumericIds(t *testing.T) {
 }
 
 func TestMigrationWithHoles(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
 	memoryMigration := &MemoryMigrationSource{
 		Files: map[string]string{
 			"1_init.up.sql":            "",
@@ -130,7 +135,7 @@ func TestMigrationWithHoles(t *testing.T) {
 	}
 
 	driver := getMockDriver()
-	applied, err := Migrate(driver, memoryMigration, Up, 0)
+	applied, err := Migrate(ctx, driver, memoryMigration, Up, 0)
 	if err != nil {
 		t.Errorf("Unexpected error while performing asset migration: %s", err)
 	}
@@ -147,7 +152,7 @@ func TestMigrationWithHoles(t *testing.T) {
 	memoryMigration.Files["4_another_update.up.sql"] = ""
 	memoryMigration.Files["4_another_update.up.sql"] = ""
 
-	applied2, err := Migrate(driver, memoryMigration, Up, 0)
+	applied2, err := Migrate(ctx, driver, memoryMigration, Up, 0)
 	if err != nil {
 		t.Errorf("Unexpected error while performing asset migration: %s", err)
 	}
@@ -160,6 +165,9 @@ func TestMigrationWithHoles(t *testing.T) {
 }
 
 func TestMigrateUpWithLimit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
 	memoryMigration := &MemoryMigrationSource{
 		Files: map[string]string{
 			"1_init.up.sql":             "",
@@ -174,7 +182,7 @@ func TestMigrateUpWithLimit(t *testing.T) {
 	}
 
 	driver := getMockDriver()
-	applied, err := Migrate(driver, memoryMigration, Up, 2)
+	applied, err := Migrate(ctx, driver, memoryMigration, Up, 2)
 	if err != nil {
 		t.Errorf("Unexpected error while performing asset migration: %s", err)
 	}
@@ -185,7 +193,7 @@ func TestMigrateUpWithLimit(t *testing.T) {
 		t.Errorf("Applied %d migrations, but driver is showing %d applied.", applied, len(driver.applied))
 	}
 
-	applied2, err := Migrate(driver, memoryMigration, Up, 2)
+	applied2, err := Migrate(ctx, driver, memoryMigration, Up, 2)
 	if err != nil {
 		t.Errorf("Unexpected error while performing asset migration: %s", err)
 	}
@@ -198,6 +206,9 @@ func TestMigrateUpWithLimit(t *testing.T) {
 }
 
 func TestMigrateDownWithLimit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
 	memoryMigration := &MemoryMigrationSource{
 		Files: map[string]string{
 			"1_init.up.sql":             "",
@@ -212,7 +223,7 @@ func TestMigrateDownWithLimit(t *testing.T) {
 	}
 
 	driver := getMockDriver()
-	applied, err := Migrate(driver, memoryMigration, Up, 0)
+	applied, err := Migrate(ctx, driver, memoryMigration, Up, 0)
 	if err != nil {
 		t.Errorf("Unexpected error while performing asset migration: %s", err)
 	}
@@ -223,7 +234,7 @@ func TestMigrateDownWithLimit(t *testing.T) {
 		t.Errorf("Applied %d migrations, but driver is showing %d applied.", applied, len(driver.applied))
 	}
 
-	applied2, err := Migrate(driver, memoryMigration, Down, 2)
+	applied2, err := Migrate(ctx, driver, memoryMigration, Down, 2)
 	if err != nil {
 		t.Errorf("Unexpected error while performing asset migration: %s", err)
 	}
@@ -236,6 +247,9 @@ func TestMigrateDownWithLimit(t *testing.T) {
 }
 
 func TestMigrationWithError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
 	memoryMigration := &MemoryMigrationSource{
 		Files: map[string]string{
 			"1_init.up.sql":     "",
@@ -246,7 +260,7 @@ func TestMigrationWithError(t *testing.T) {
 	}
 
 	driver := getMockDriver()
-	applied, err := Migrate(driver, memoryMigration, Up, 2)
+	applied, err := Migrate(ctx, driver, memoryMigration, Up, 2)
 	if err == nil {
 		t.Error("Expected error while running migration, but there was no error")
 	}
@@ -254,7 +268,7 @@ func TestMigrationWithError(t *testing.T) {
 		t.Errorf("%d migrations should be applied, but %d was applied.", 1, applied)
 	}
 
-	applied2, err := Migrate(driver, memoryMigration, Down, 1)
+	applied2, err := Migrate(ctx, driver, memoryMigration, Down, 1)
 	if err == nil {
 		t.Error("Expected error while running migration, but there was no error")
 	}

--- a/mock.go
+++ b/mock.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -11,11 +12,11 @@ type mockDriver struct {
 	applied []string
 }
 
-func (m *mockDriver) Close() error {
+func (m *mockDriver) Close(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockDriver) Migrate(migration *PlannedMigration) error {
+func (m *mockDriver) Migrate(ctx context.Context, migration *PlannedMigration) error {
 	var migrationStatements *parser.ParsedMigration
 
 	if migration.Direction == Up {
@@ -56,7 +57,7 @@ func (m *mockDriver) Migrate(migration *PlannedMigration) error {
 	return nil
 }
 
-func (m *mockDriver) Versions() ([]string, error) {
+func (m *mockDriver) Versions(ctx context.Context) ([]string, error) {
 	return m.applied, nil
 }
 


### PR DESCRIPTION
This updates the `Driver` interface to use context as the first parameter for anything that ultimately queries the database. Additionally, the Postgres driver was updated to use the native pgx types (instead of `database/sql`) to allow it to accept either a plain `*pgx.Conn` or a `*pgxpool.Pool`.

You will probably need to bump the versions and go mod files for each of these two packages as part of this, otherwise the driver refers to an older version of the parent package that doesn't have the new interface types.